### PR TITLE
First version of login flow

### DIFF
--- a/Digijam.xcodeproj/project.pbxproj
+++ b/Digijam.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		31074BE91A156B1F003F7557 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31074BE71A156B1F003F7557 /* LoginViewController.swift */; };
 		3120FEAE1A361EE700411EFA /* Locksmith.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3120FEAC1A361EE700411EFA /* Locksmith.swift */; };
 		3120FEAF1A361EE700411EFA /* LocksmithRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3120FEAD1A361EE700411EFA /* LocksmithRequest.swift */; };
+		315728661A48710E0010C895 /* UserManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 315728651A48710E0010C895 /* UserManager.swift */; };
 		31A0AC751A1566E000C74702 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31A0AC741A1566E000C74702 /* AppDelegate.swift */; };
 		31A0AC771A1566E000C74702 /* FeedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31A0AC761A1566E000C74702 /* FeedViewController.swift */; };
 		31A0AC7A1A1566E000C74702 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 31A0AC781A1566E000C74702 /* Main.storyboard */; };
@@ -77,6 +78,7 @@
 		31074BE71A156B1F003F7557 /* LoginViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		3120FEAC1A361EE700411EFA /* Locksmith.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Locksmith.swift; sourceTree = "<group>"; };
 		3120FEAD1A361EE700411EFA /* LocksmithRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocksmithRequest.swift; sourceTree = "<group>"; };
+		315728651A48710E0010C895 /* UserManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserManager.swift; sourceTree = "<group>"; };
 		31A0AC6F1A1566E000C74702 /* Digijam.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Digijam.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		31A0AC731A1566E000C74702 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		31A0AC741A1566E000C74702 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -148,6 +150,7 @@
 				31A0AC761A1566E000C74702 /* FeedViewController.swift */,
 				D8C986B01A1BFA850093C217 /* FirebaseAPI.swift */,
 				31074BE61A156B1F003F7557 /* GithubAPI.swift */,
+				315728651A48710E0010C895 /* UserManager.swift */,
 				31074BE71A156B1F003F7557 /* LoginViewController.swift */,
 				31E424751A1B98530075256E /* LoginProtocol.swift */,
 				31A0AC781A1566E000C74702 /* Main.storyboard */,
@@ -328,6 +331,7 @@
 				D808B4C11A237BC1004BF515 /* CoreDataManager.swift in Sources */,
 				D8BF55F01A1BD5BC00AE78F8 /* PrivateKeys.swift in Sources */,
 				D8027E661A26126F00D38645 /* User.swift in Sources */,
+				315728661A48710E0010C895 /* UserManager.swift in Sources */,
 				D8C986B11A1BFA850093C217 /* FirebaseAPI.swift in Sources */,
 				3120FEAE1A361EE700411EFA /* Locksmith.swift in Sources */,
 			);

--- a/Digijam/GithubAPI.swift
+++ b/Digijam/GithubAPI.swift
@@ -12,8 +12,6 @@ import CoreData
 
 class GithubAPI {
     
-
-    
     class func getAccessToken () -> ([String : String]?, error : NSError?)
     {
         var service = "githubAccess"
@@ -53,7 +51,7 @@ class GithubAPI {
             
         Locksmith.saveData(["access_token": accessTokenResults["access_token"] as String], forKey: accessTokenDictionary, inService: service, forUserAccount: userAccount)
 
-            GithubAPI.getUser()
+            GithubAPI.getAuthenticatedUserData()
         })
     }
     
@@ -66,14 +64,13 @@ class GithubAPI {
             
             var userResult = self.parseJSON(data as NSData)
             
-            //need to check if the user is already in our datastore so we don't add duplicates here!
-            
+            if let githubID = userResult["id"] as? Int {
+                
+                UserManager.findOrCreateUserWithGithubID(String(githubID), completion: { (error) -> Void in
+                    //what do we want to do here?
+                })
+            }
         })
-    }
-    
-    
-    class func saveUserDictionaryAsUser(githubUser: NSDictionary) {
-        
     }
 
     class func parseJSON(inputData: NSData) -> NSDictionary{

--- a/Digijam/GithubAPI.swift
+++ b/Digijam/GithubAPI.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 import Alamofire
+import CoreData
 
 class GithubAPI {
     
@@ -52,13 +53,29 @@ class GithubAPI {
             
         Locksmith.saveData(["access_token": accessTokenResults["access_token"] as String], forKey: accessTokenDictionary, inService: service, forUserAccount: userAccount)
 
-            //self.getUserDefaults().setObject(accessTokenDictionary["access_token"] as? String, forKey: "access_token")
+            GithubAPI.getUser()
+        })
+    }
+    
+    class func getAuthenticatedUserData() {
+
+        var user : User
+        let userDetailsURL = "https://api.github.com/user?"
+        let accessTokenDictionary : [String:String]? = GithubAPI.getAccessToken().0
+        Alamofire.request(.GET, userDetailsURL, parameters:accessTokenDictionary ).response({(request, response, data, error) in
             
-            //self.getUserDefaults().synchronize()
+            var userResult = self.parseJSON(data as NSData)
+            
+            //need to check if the user is already in our datastore so we don't add duplicates here!
             
         })
     }
     
+    
+    class func saveUserDictionaryAsUser(githubUser: NSDictionary) {
+        
+    }
+
     class func parseJSON(inputData: NSData) -> NSDictionary{
         var error: NSError?
         var dataDictionary: NSDictionary = NSJSONSerialization.JSONObjectWithData(inputData, options: NSJSONReadingOptions.MutableContainers, error: &error) as NSDictionary

--- a/Digijam/User+GithubAddOns.swift
+++ b/Digijam/User+GithubAddOns.swift
@@ -1,0 +1,9 @@
+//
+//  User+GithubAddOns.swift
+//  Digijam
+//
+//  Created by Zachary Drossman on 12/22/14.
+//  Copyright (c) 2014 Zachary Drossman. All rights reserved.
+//
+
+import Foundation

--- a/Digijam/UserManager.swift
+++ b/Digijam/UserManager.swift
@@ -14,34 +14,37 @@ class UserManager: NSObject {
     struct Static {
         static let instance : UserManager = UserManager()
         static var currentUser : User?
-        static let dataManager : CoreDataManager = CoreDataManager.sharedInstance
     }
         
     class var sharedInstance : UserManager {
                 return Static.instance
     }
     
-    class func findOrCreateUserWithGithubID(githubID: String, completion: (error: NSError) -> Void) {
-        if let foundUser = findUserWithGithubID(githubID) {
+    class var currentUser: User? {
+        return Static.currentUser
+    }
+    
+    class func findOrCreateUserWithGithubID(githubID: String, context: NSManagedObjectContext, completion: (error: NSError) -> Void) {
+        if let foundUser = findUserWithGithubID(githubID, context: context) {
             Static.currentUser = foundUser
         }
         else {
-            createUserWithGithubID(githubID)
+            createUserWithGithubID(githubID, context: context)
             //create calls to find / create on Firebase, with success / failure returns (?)
         }
     }
     
-    class func findUserWithGithubID(githubID: String) -> User? {
+    class func findUserWithGithubID(githubID: String, context: NSManagedObjectContext) -> User? {
         
         var fetchRequest = NSFetchRequest()
-        var entity = NSEntityDescription.entityForName("User", inManagedObjectContext: Static.dataManager.managedObjectContext)
+        var entity = NSEntityDescription.entityForName("User", inManagedObjectContext: context)
         
         fetchRequest.entity = entity
         
         let predicate = NSPredicate(format: "githubID == %@", githubID)
         fetchRequest.predicate = predicate
         
-        let foundUsers = Static.dataManager.managedObjectContext.executeFetchRequest(fetchRequest, error: nil) as? [User]
+        let foundUsers = context.executeFetchRequest(fetchRequest, error: nil) as? [User]
         
         if var foundUser = foundUsers?.first {
             return foundUser
@@ -50,35 +53,35 @@ class UserManager: NSObject {
         return nil
     }
     
-    class func createUserWithGithubID(githubID: String) {
+    class func createUserWithGithubID(githubID: String, context: NSManagedObjectContext) {
         
-        var user: User = NSEntityDescription.insertNewObjectForEntityForName("User", inManagedObjectContext: CoreDataManager.sharedInstance.managedObjectContext) as User
+        var user = User.insert(context)
         
-//        if let githubID: String = userResult["id"] as? String {
+        if let githubID: String = userResult["id"] as? String {
             user.githubID = githubID
-//        }
+        }
         
-//        if let username: String = userResult["name"] as? String {
-//            
-//            let startOfFirstName = username.startIndex
-//            //assumes no middle name for now, can revamp this implementation to account for various names later
-//            let endOfFirstName = find(username, " ")
-//            let beginningOfLastName = advance(start: endOfFirstName, n: 1, nil)
-//            
-//            let endOfLastName = username.endIndex
-//            
-//            if let endOfFirstName = endOfFirstName {
-//                user.firstName = username.substringWithRange(Range(start: startOfFirstName,end: endOfFirstName))
-//                
-//                user.lastName = username.substringWithRange(Range(start:beginningOfLastName, end: endOfLastName))
-//            }
-//            else {
-//                //uses login (i.e. actual username) if the user's name is not complete, as a starting point.
-//                if let firstName = userResult["login"] as String? {
-//                    user.firstName = firstName
-//                }
-//            }
-//        }
+        if let username: String = userResult["name"] as? String {
+            
+            let startOfFirstName = username.startIndex
+            //assumes no middle name for now, can revamp this implementation to account for various names later
+            let endOfFirstName = find(username, " ")
+            let beginningOfLastName = advance(start: endOfFirstName, n: 1, nil)
+            
+            let endOfLastName = username.endIndex
+            
+            if let endOfFirstName = endOfFirstName {
+                user.firstName = username.substringWithRange(Range(start: startOfFirstName,end: endOfFirstName))
+                
+                user.lastName = username.substringWithRange(Range(start:beginningOfLastName, end: endOfLastName))
+            }
+            else {
+                //uses login (i.e. actual username) if the user's name is not complete, as a starting point.
+                if let firstName = userResult["login"] as String? {
+                    user.firstName = firstName
+                }
+            }
+        }
         
     }
     

--- a/Digijam/UserManager.swift
+++ b/Digijam/UserManager.swift
@@ -1,0 +1,64 @@
+//
+//  UserManager.swift
+//  Digijam
+//
+//  Created by Zachary Drossman on 12/22/14.
+//  Copyright (c) 2014 Zachary Drossman. All rights reserved.
+//
+
+import UIKit
+import CoreData
+
+class UserManager: NSObject {
+   
+    var dataManager = CoreDataManager.sharedInstance
+    
+    class func findUserWithGithubID(githubID: String) -> User? {
+        
+        var fetchRequest = NSFetchRequest()
+        var entity = NSEntityDescription.entityForName("User", inManagedObjectContext: dataManager.managedObjectContext)
+        
+        fetchRequest.entity = entity
+        
+        let predicate = NSPredicate(format: "githubID == %@", githubID)
+        fetchRequest.predicate = predicate
+        
+        var error = NSError()
+        var foundUser : User? = dataManager.managedObjectContext.executeFetchRequest(fetchRequest,error)
+    
+        return foundUser
+    }
+    
+    class func createUserWithGithubID(githubID: String) {
+        
+        var user: User = NSEntityDescription.insertNewObjectForEntityForName("User", inManagedObjectContext: CoreDataManager.sharedInstance.managedObjectContext) as User
+        
+        if let githubID: String = userResult["id"] as? String {
+            user.githubID = githubID
+        }
+        
+        if let username: String = userResult["name"] as? String {
+            
+            let startOfFirstName = username.startIndex
+            //assumes no middle name for now, can revamp this implementation to account for various names later
+            let endOfFirstName = find(username, " ")
+            let beginningOfLastName = advance(start: endOfFirstName, n: 1, nil)
+            
+            let endOfLastName = username.endIndex
+            
+            if let endOfFirstName = endOfFirstName {
+                user.firstName = username.substringWithRange(Range(start: startOfFirstName,end: endOfFirstName))
+                
+                user.lastName = username.substringWithRange(Range(start:beginningOfLastName, end: endOfLastName))
+            }
+            else {
+                //uses login (i.e. actual username) if the user's name is not complete, as a starting point.
+                if let firstName = userResult["login"] as String? {
+                    user.firstName = firstName
+                }
+            }
+        }
+        
+    }
+    
+}

--- a/Digijam/UserManager.swift
+++ b/Digijam/UserManager.swift
@@ -10,54 +10,75 @@ import UIKit
 import CoreData
 
 class UserManager: NSObject {
-   
-    var dataManager = CoreDataManager.sharedInstance
+    
+    struct Static {
+        static let instance : UserManager = UserManager()
+        static var currentUser : User?
+        static let dataManager : CoreDataManager = CoreDataManager.sharedInstance
+    }
+        
+    class var sharedInstance : UserManager {
+                return Static.instance
+    }
+    
+    class func findOrCreateUserWithGithubID(githubID: String, completion: (error: NSError) -> Void) {
+        if let foundUser = findUserWithGithubID(githubID) {
+            Static.currentUser = foundUser
+        }
+        else {
+            createUserWithGithubID(githubID)
+            //create calls to find / create on Firebase, with success / failure returns (?)
+        }
+    }
     
     class func findUserWithGithubID(githubID: String) -> User? {
         
         var fetchRequest = NSFetchRequest()
-        var entity = NSEntityDescription.entityForName("User", inManagedObjectContext: dataManager.managedObjectContext)
+        var entity = NSEntityDescription.entityForName("User", inManagedObjectContext: Static.dataManager.managedObjectContext)
         
         fetchRequest.entity = entity
         
         let predicate = NSPredicate(format: "githubID == %@", githubID)
         fetchRequest.predicate = predicate
         
-        var error = NSError()
-        var foundUser : User? = dataManager.managedObjectContext.executeFetchRequest(fetchRequest,error)
-    
-        return foundUser
+        let foundUsers = Static.dataManager.managedObjectContext.executeFetchRequest(fetchRequest, error: nil) as? [User]
+        
+        if var foundUser = foundUsers?.first {
+            return foundUser
+        }
+        
+        return nil
     }
     
     class func createUserWithGithubID(githubID: String) {
         
         var user: User = NSEntityDescription.insertNewObjectForEntityForName("User", inManagedObjectContext: CoreDataManager.sharedInstance.managedObjectContext) as User
         
-        if let githubID: String = userResult["id"] as? String {
+//        if let githubID: String = userResult["id"] as? String {
             user.githubID = githubID
-        }
+//        }
         
-        if let username: String = userResult["name"] as? String {
-            
-            let startOfFirstName = username.startIndex
-            //assumes no middle name for now, can revamp this implementation to account for various names later
-            let endOfFirstName = find(username, " ")
-            let beginningOfLastName = advance(start: endOfFirstName, n: 1, nil)
-            
-            let endOfLastName = username.endIndex
-            
-            if let endOfFirstName = endOfFirstName {
-                user.firstName = username.substringWithRange(Range(start: startOfFirstName,end: endOfFirstName))
-                
-                user.lastName = username.substringWithRange(Range(start:beginningOfLastName, end: endOfLastName))
-            }
-            else {
-                //uses login (i.e. actual username) if the user's name is not complete, as a starting point.
-                if let firstName = userResult["login"] as String? {
-                    user.firstName = firstName
-                }
-            }
-        }
+//        if let username: String = userResult["name"] as? String {
+//            
+//            let startOfFirstName = username.startIndex
+//            //assumes no middle name for now, can revamp this implementation to account for various names later
+//            let endOfFirstName = find(username, " ")
+//            let beginningOfLastName = advance(start: endOfFirstName, n: 1, nil)
+//            
+//            let endOfLastName = username.endIndex
+//            
+//            if let endOfFirstName = endOfFirstName {
+//                user.firstName = username.substringWithRange(Range(start: startOfFirstName,end: endOfFirstName))
+//                
+//                user.lastName = username.substringWithRange(Range(start:beginningOfLastName, end: endOfLastName))
+//            }
+//            else {
+//                //uses login (i.e. actual username) if the user's name is not complete, as a starting point.
+//                if let firstName = userResult["login"] as String? {
+//                    user.firstName = firstName
+//                }
+//            }
+//        }
         
     }
     

--- a/Digijam/UserManager.swift
+++ b/Digijam/UserManager.swift
@@ -56,33 +56,6 @@ class UserManager: NSObject {
     class func createUserWithGithubID(githubID: String, context: NSManagedObjectContext) {
         
         var user = User.insert(context)
-        
-        if let githubID: String = userResult["id"] as? String {
-            user.githubID = githubID
-        }
-        
-        if let username: String = userResult["name"] as? String {
-            
-            let startOfFirstName = username.startIndex
-            //assumes no middle name for now, can revamp this implementation to account for various names later
-            let endOfFirstName = find(username, " ")
-            let beginningOfLastName = advance(start: endOfFirstName, n: 1, nil)
-            
-            let endOfLastName = username.endIndex
-            
-            if let endOfFirstName = endOfFirstName {
-                user.firstName = username.substringWithRange(Range(start: startOfFirstName,end: endOfFirstName))
-                
-                user.lastName = username.substringWithRange(Range(start:beginningOfLastName, end: endOfLastName))
-            }
-            else {
-                //uses login (i.e. actual username) if the user's name is not complete, as a starting point.
-                if let firstName = userResult["login"] as String? {
-                    user.firstName = firstName
-                }
-            }
-        }
-        
     }
     
 }


### PR DESCRIPTION
Includes a UserManager class that will find / create user in CoreData based on a githubID; allows us to get authenticated user data from githubAPI to pass to this class.

NB: These methods in UserManager are not distinct to the currentUser, though they currently save the user as currentUser when called; might be worth providing further functionality to them so that they might be re-used upon creation of other User objects when pulled from github based on a class roll. Something to think about, and if we don't want to do this, we should spend a few minutes discussing the structure for the rest of the users and how we interact with them next time we are working on this.

<!---
@huboard:{"order":5.5,"milestone_order":17,"custom_state":""}
-->
